### PR TITLE
Add action for building and running terraform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,9 @@ jobs:
   terraform:
     name: "Terraform Deployment"
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: terraform
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Adding in CI before starting lambda and infra development. Would be nice if I had a separate dev/prod environments but I don't want to pay for all the additional infrastructure for that.