### PR TITLE
Include TZData as it may not be included in runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,8 @@ jobs:
       - run: go mod download
       - run: go vet ./...
       - run: mkdir -p build/bin
-      - run: go build -tags lambda.norpc -v -o build/bin/harvestcalls/bootstrap lambdas/harvestcalls/main.go
-      - run: go build -tags lambda.norpc -v -o build/bin/active_call_notifier/bootstrap lambdas/active_call_notifier/main.go
+      - run: go build -tags "lambda.norpc timetzdata" -v -o build/bin/harvestcalls/bootstrap lambdas/harvestcalls/main.go
+      - run: go build -tags "lambda.norpc timetzdata" -v -o build/bin/active_call_notifier/bootstrap lambdas/active_call_notifier/main.go
       - run: go get github.com/onsi/ginkgo/v2/ginkgo
       - run: go run github.com/onsi/ginkgo/v2/ginkgo -r --randomize-all --randomize-suites --race --trace --fail-on-pending --keep-going
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Getting an error when parsing dates:
> panic: time: missing Location in call to Date

May be because the runtime doesn't include timezone info in any of the locations that golang looks for it. From https://pkg.go.dev/time#LoadLocation:

> LoadLocation looks for the IANA Time Zone database in the following locations in order:
> 
> * the directory or uncompressed zip file named by the ZONEINFO environment variable
> * on a Unix system, the system standard installation location
> * $GOROOT/lib/time/zoneinfo.zip
> * the time/tzdata package, if it was imported

Must be that the new runtime does not include any of the top three, but including the tzdata package within my binary may fix it.