### PR TITLE
add basic cloudwatch monitoring to lambdas

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,7 @@ jobs:
       TF_VAR_TWILIO_API_KEY: ${{ secrets.TWILIO_API_KEY }}
       TF_VAR_TWILIO_API_SECRET: ${{ secrets.TWILIO_API_SECRET }}
       TF_VAR_STREET_NAMES: ${{ secrets.STREET_NAMES }}
+      TF_VAR_OPS_EMAIL: ${{ secrets.OPS_EMAIL }}
     steps:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -37,3 +37,8 @@ variable "STREET_NAMES" {
   type      = list(string)
   sensitive = true
 }
+
+variable "OPS_EMAIL" {
+  type      = string
+  sensitive = true
+}


### PR DESCRIPTION
To catch the next time things get broken by API changes, going to add some basic monitoring that should stay within free-tier limits