### PR TITLE
chore: dependabot is noisy, make fewer PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,18 @@ updates:
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     groups:
       aws-sdk-go:
         patterns:
-         - "github.com/aws/aws-sdk-go-v2"
-         - "github.com/aws/aws-sdk-go-v2/*"
+          - "github.com/aws/aws-sdk-go-v2"
+          - "github.com/aws/aws-sdk-go-v2/*"
+      test-packages:
+        patterns:
+          - "github.com/go-resty/resty/v2"
+          - "github.com/jarcoal/httpmock"
+          - "github.com/onsi/*"
+          - "github.com/stretchr/testify"
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
I'm fine with merging PRs every once in a while, but the purpose here is to keep things from getting too far out of date. I don't need the most recent patch update from the AWS SDK every week.